### PR TITLE
feat: Add config subsystem based on json-file

### DIFF
--- a/SimpleStateMachineNodeEditor/App.xaml.cs
+++ b/SimpleStateMachineNodeEditor/App.xaml.cs
@@ -1,9 +1,10 @@
 ﻿using System.Reflection;
-using System.Windows;
+using Microsoft.Extensions.Configuration;
 using ReactiveUI;
+using SimpleStateMachineNodeEditor.Helpers.Configuration;
 using Splat;
-using SimpleStateMachineNodeEditor.Helpers;
 using SimpleStateMachineNodeEditor.Helpers.Converters;
+using Application = System.Windows.Application;
 
 namespace SimpleStateMachineNodeEditor
 {
@@ -16,7 +17,18 @@ namespace SimpleStateMachineNodeEditor
         {
             Locator.CurrentMutable.RegisterViewsForViewModels(Assembly.GetCallingAssembly());
             Locator.CurrentMutable.RegisterConstant(new ConverterBoolAndVisibility(), typeof(IBindingTypeConverter));
-        }
 
+            IConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+            IConfigurationRoot configuration = configurationBuilder.Add<WritableJsonConfigurationSource>(s =>
+                {
+                    s.FileProvider = null;
+                    s.Path = "Settings.json";
+                    s.Optional = true;
+                    s.ReloadOnChange = true;
+                    s.ResolveFileProvider();
+                }).Build();
+
+            Locator.CurrentMutable.RegisterConstant(configuration, typeof(IConfiguration));
+        }
     }
 }

--- a/SimpleStateMachineNodeEditor/AppSettings.cs
+++ b/SimpleStateMachineNodeEditor/AppSettings.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using SimpleStateMachineNodeEditor.Helpers.Enums;
+
+namespace SimpleStateMachineNodeEditor
+{
+    public class AppSettings
+    {
+        public class AppearanceSettings
+        {
+            [JsonConverter(typeof(StringEnumConverter))]
+            public Themes Theme { get; set; }
+        }
+
+        public AppearanceSettings Appearance { get; set; }
+    }
+}

--- a/SimpleStateMachineNodeEditor/Helpers/Configuration/WritableJsonConfigurationProvider.cs
+++ b/SimpleStateMachineNodeEditor/Helpers/Configuration/WritableJsonConfigurationProvider.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.IO;
+using Microsoft.Extensions.Configuration.Json;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SimpleStateMachineNodeEditor.Helpers.Configuration
+{
+    public class WritableJsonConfigurationProvider : JsonConfigurationProvider
+    {
+        public WritableJsonConfigurationProvider(JsonConfigurationSource source) : base(source)
+        {
+        }
+
+        private void Save(dynamic jsonObj)
+        {
+            var fileFullPath = base.Source.FileProvider.GetFileInfo(base.Source.Path).PhysicalPath;
+            string output = JsonConvert.SerializeObject(jsonObj, Formatting.Indented);
+            File.WriteAllText(fileFullPath, output);
+        }
+
+        private void SetValue(string key, string value, dynamic jsonObj)
+        {
+            base.Set(key, value);
+            var split = key.Split(":");
+            var context = jsonObj;
+            for (int i = 0; i < split.Length; i++)
+            {
+                var currentKey = split[i];
+                if (i < split.Length - 1)
+                {
+                    var child = jsonObj[currentKey];
+                    if (child == null)
+                    {
+                        context[currentKey] = new JObject();
+                    }
+                    context = context[currentKey];
+                }
+                else
+                {
+                    context[currentKey] = value;
+                }
+            }
+        }
+
+        private dynamic GetJsonObj()
+        {
+            var fileFullPath = base.Source.FileProvider.GetFileInfo(base.Source.Path).PhysicalPath;
+            var json = File.Exists(fileFullPath) ? File.ReadAllText(fileFullPath) : "{}";
+            return JsonConvert.DeserializeObject(json);
+        }
+
+        public override void Set(string key, string value)
+        {
+            var jsonObj = GetJsonObj();
+            SetValue(key, value, jsonObj);
+            Save(jsonObj);
+        }
+
+        public void Set(string key, object value)
+        {
+            var jsonObj = GetJsonObj();
+            var serialized = JsonConvert.SerializeObject(value);
+            var jToken = JsonConvert.DeserializeObject(serialized) as JToken ?? new JValue(value);
+            WalkAndSet(key, jToken, jsonObj);
+            Save(jsonObj);
+        }
+
+        private void WalkAndSet(string key, JToken value, dynamic jsonObj)
+        {
+            switch (value)
+            {
+                case JArray jArray:
+                {
+                    //TODO Realize arrays
+                    break;
+                }
+                case JObject jObject:
+                {
+                    foreach (var propertyInfo in jObject.Properties())
+                    {
+                        var propName = propertyInfo.Name;
+                        var currentKey = key == null ? propName : $"{key}:{propName}";
+                        var propValue = propertyInfo.Value;
+                        WalkAndSet(currentKey, propValue, jsonObj);
+                    }
+                    break;
+                }
+                case JValue jValue:
+                {
+                    SetValue(key, jValue.ToString(), jsonObj);
+                    break;
+                }
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value));
+            }
+        }
+    }
+}

--- a/SimpleStateMachineNodeEditor/Helpers/Configuration/WritableJsonConfigurationProviderExtensions.cs
+++ b/SimpleStateMachineNodeEditor/Helpers/Configuration/WritableJsonConfigurationProviderExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+
+namespace SimpleStateMachineNodeEditor.Helpers.Configuration
+{
+    public static class WritableJsonConfigurationProviderExtensions
+    {
+        public static void Set(this IConfiguration configuration, object value)
+        {
+            switch (configuration)
+            {
+                case IConfigurationRoot configurationRoot:
+                {
+                    var provider = configurationRoot.Providers.First(p => p is WritableJsonConfigurationProvider) as WritableJsonConfigurationProvider;
+                    provider.Set(null, value);
+                    break;
+                }
+                case ConfigurationSection configurationSection:
+                {
+                    var rootProp = typeof(ConfigurationSection).GetField("_root", BindingFlags.NonPublic | BindingFlags.Instance); ;
+                    var root = rootProp.GetValue(configurationSection) as IConfigurationRoot;
+                    var provider = root.Providers.First(p => p is WritableJsonConfigurationProvider) as WritableJsonConfigurationProvider;
+                    provider.Set(configurationSection.Path, value);
+                    break;
+                }
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(configuration));
+            }
+        }
+    }
+}

--- a/SimpleStateMachineNodeEditor/Helpers/Configuration/WritableJsonConfigurationSource.cs
+++ b/SimpleStateMachineNodeEditor/Helpers/Configuration/WritableJsonConfigurationSource.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
+
+namespace SimpleStateMachineNodeEditor.Helpers.Configuration
+{
+    public class WritableJsonConfigurationSource : JsonConfigurationSource
+    {
+        public override IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            this.EnsureDefaults(builder);
+            return (IConfigurationProvider)new WritableJsonConfigurationProvider(this);
+        }
+    }
+}

--- a/SimpleStateMachineNodeEditor/SimpleStateMachineNodeEditor.csproj
+++ b/SimpleStateMachineNodeEditor/SimpleStateMachineNodeEditor.csproj
@@ -62,6 +62,9 @@ ReactiveUI 11.4.17</PackageReleaseNotes>
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ReactiveUI" Version="11.4.17" />
     <PackageReference Include="ReactiveUI.Events.WPF" Version="11.4.17" />
     <PackageReference Include="ReactiveUI.Fody" Version="11.4.17" />

--- a/SimpleStateMachineNodeEditor/ViewModel/NodesCanvas/ViewModelNodesCanvas.cs
+++ b/SimpleStateMachineNodeEditor/ViewModel/NodesCanvas/ViewModelNodesCanvas.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Windows.Controls;
 using System.Windows.Media;
 using DynamicData;
+using Microsoft.Extensions.Configuration;
 
 namespace SimpleStateMachineNodeEditor.ViewModel
 {
@@ -45,10 +46,10 @@ namespace SimpleStateMachineNodeEditor.ViewModel
         /// Flag for close application
         /// </summary>
         [Reactive] public bool NeedExit { get; set; }
-        [Reactive] public string ImagePath{ get; set; }
+        [Reactive] public string ImagePath { get; set; }
         [Reactive] public ImageFormats ImageFormat { get; set; }
         [Reactive] public bool WithoutMessages { get; set; }
-        [Reactive]  public Themes Theme { get; set; } = Themes.Dark;
+        [Reactive] public Themes Theme { get; set; }
 
 
 
@@ -63,10 +64,14 @@ namespace SimpleStateMachineNodeEditor.ViewModel
         public double ScaleMax = 5;
         public double ScaleMin = 0.1;
         public double Scales { get; set; } = 0.05;
-        
+
 
         public ViewModelNodesCanvas()
         {
+            var configuration = Locator.Current.GetService<IConfiguration>();
+            Theme = configuration.GetSection("Appearance:Theme").Get<Themes>();
+            if (Theme == Themes.noCorrect) Theme = Themes.Dark;
+            SetTheme(Theme);
             Cutter = new ViewModelCutter(this);
             Nodes.Connect().ObserveOnDispatcher().Bind(NodesForView).Subscribe();
             SetupCommands();
@@ -107,7 +112,7 @@ namespace SimpleStateMachineNodeEditor.ViewModel
 
         public void LogDebug(string message, params object[] args)
         {
-            if(!WithoutMessages)
+            if (!WithoutMessages)
                 Messages.Add(new ViewModelMessage(TypeMessage.Debug, string.Format(message, args)));
         }
         public void LogError(string message, params object[] args)
@@ -133,7 +138,7 @@ namespace SimpleStateMachineNodeEditor.ViewModel
             if (newValue > oldValue)
             {
                 NodesCount++;
-            }   
+            }
         }
         private string SchemeName()
         {

--- a/SimpleStateMachineNodeEditor/ViewModel/NodesCanvas/ViewModelNodesCanvasCommands.cs
+++ b/SimpleStateMachineNodeEditor/ViewModel/NodesCanvas/ViewModelNodesCanvasCommands.cs
@@ -12,6 +12,9 @@ using System.Reactive.Linq;
 using System.Windows;
 using System.Windows.Input;
 using System.Xml.Linq;
+using Microsoft.Extensions.Configuration;
+using SimpleStateMachineNodeEditor.Helpers.Configuration;
+using Splat;
 
 namespace SimpleStateMachineNodeEditor.ViewModel
 {
@@ -137,7 +140,6 @@ namespace SimpleStateMachineNodeEditor.ViewModel
             CommandChangeNodeName = new Command<(ViewModelNode node, string newName), (ViewModelNode node, string oldName)>(ChangeNodeName, UnChangeNodeName);
             CommandChangeConnectName = new Command<(ViewModelConnector connector, string newName), (ViewModelConnector connector, string oldName)>(ChangeConnectName, UnChangeConnectName);
 
-
             NotSavedSubscrube();
         }
 
@@ -189,6 +191,8 @@ namespace SimpleStateMachineNodeEditor.ViewModel
         }
         private void SetTheme(Themes theme)
         {
+            var configuration = Locator.Current.GetService<IConfiguration>();
+            configuration.GetSection("Appearance:Theme").Set(theme);
             Application.Current.Resources.Clear();
             var uri = new Uri(themesPaths[theme], UriKind.RelativeOrAbsolute);
             ResourceDictionary resourceDict = Application.LoadComponent(uri) as ResourceDictionary;


### PR DESCRIPTION
I implemented a runtime-modifiable configuration using a json file.
To get a configuration instance you need to use Splat:
`var configuration = Locator.Current.GetService<IConfiguration>();`

You can get the value like this:
`var theme = configuration.GetSection("Appearance:Theme").Get<Themes>();`

To change the value in the configuration file you can do this:
`configuration.GetSection("Appearance:Theme").Set(Themes.Dark);`

An alternative way to work with a configuration is to use the configuration type:
```
var settings = configuration.Get<AppSettings>();
settings.Appearance.Theme = Themes.Light;
configuration.Set(settings);
```