### PR TITLE
feature: Let Roslyn Generate x:Name References

### DIFF
--- a/SimpleStateMachineNodeEditorAvalonia/SimpleStateMachineNodeEditorAvalonia.csproj
+++ b/SimpleStateMachineNodeEditorAvalonia/SimpleStateMachineNodeEditorAvalonia.csproj
@@ -20,18 +20,19 @@
     <Compile Remove="Styles\Connector\Connector\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.0-rc1" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0-rc1" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0-rc1" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.0-rc1" />
-	<PackageReference Include="Avalonia.ReactiveUI.Events" Version="0.10.0-rc1" />
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="0.10.0-rc1" />
-    <PackageReference Include="Avalonia.Xaml.Interactions" Version="0.10.0-rc1" />
-    <PackageReference Include="Avalonia.Xaml.Interactions.Custom" Version="0.10.0-rc1" />
-    <PackageReference Include="Avalonia.Xaml.Interactivity" Version="0.10.0-rc1" />
-    <PackageReference Include="Dock.Model" Version="0.10.0-rc1" />
+    <PackageReference Include="Avalonia" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.0" />
+    <PackageReference Include="Avalonia.ReactiveUI.Events" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Xaml.Interactions" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Xaml.Interactions.Custom" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Xaml.Interactivity" Version="0.10.0" />
+    <PackageReference Include="Dock.Model" Version="0.10.0" />
     <PackageReference Include="HistoricalReactiveCommand" Version="0.5.0" />
     <PackageReference Include="ReactiveUI.Fody" Version="13.0.27" />
+    <PackageReference Include="XamlNameReferenceGenerator" Version="0.2.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <AvaloniaXaml Remove="Styles\Connect\**" />
@@ -47,5 +48,9 @@
     <None Remove="Styles\Connect\**" />
     <None Remove="Styles\Extensions\**" />
     <None Remove="Styles\Connector\Connector\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Required by XamlNameReferenceGenerator -->
+    <AdditionalFiles Include="**\*.xaml"/>
   </ItemGroup>
 </Project>

--- a/SimpleStateMachineNodeEditorAvalonia/Views/Connect/ElementsConnect.cs
+++ b/SimpleStateMachineNodeEditorAvalonia/Views/Connect/ElementsConnect.cs
@@ -12,7 +12,6 @@ namespace SimpleStateMachineNodeEditorAvalonia.Views
 {
     public partial class Connect
     {
-        public Path PathConnect;
         public PathGeometry PathGeometryConnect;
         public PathFigure PathFigureConnect;
         public BezierSegment BezierSegmentConnect;
@@ -21,7 +20,6 @@ namespace SimpleStateMachineNodeEditorAvalonia.Views
         {
             AvaloniaXamlLoader.Load(this);
 
-            PathConnect = this.FindControlWithExeption<Path>("PathConnect");
             PathGeometryConnect = PathConnect.Data as PathGeometry;
             PathFigureConnect = PathGeometryConnect.Figures.First();
             BezierSegmentConnect = PathFigureConnect.Segments.First() as BezierSegment;

--- a/SimpleStateMachineNodeEditorAvalonia/Views/Cutter/ElementsCutter.cs
+++ b/SimpleStateMachineNodeEditorAvalonia/Views/Cutter/ElementsCutter.cs
@@ -10,13 +10,9 @@ namespace SimpleStateMachineNodeEditorAvalonia.Views
 {
     public partial class Cutter
     {
-        public Line LineCutter;
-
         protected override void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            LineCutter = this.FindControlWithExeption<Line>("LineCutter");
         }
     }
 }

--- a/SimpleStateMachineNodeEditorAvalonia/Views/MainWindow/ElementsMainWindow.cs
+++ b/SimpleStateMachineNodeEditorAvalonia/Views/MainWindow/ElementsMainWindow.cs
@@ -9,14 +9,9 @@ namespace SimpleStateMachineNodeEditorAvalonia.Views
 {
     public partial class MainWindow
     {
-        public NodesCanvas NodesCanvasMainWindow;
-
         protected virtual void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            NodesCanvasMainWindow = this.FindControlWithExeption<NodesCanvas>("NodesCanvasMainWindow");
         }
-
     }
 }

--- a/SimpleStateMachineNodeEditorAvalonia/Views/Node/Connectors/ElementsConnectors.cs
+++ b/SimpleStateMachineNodeEditorAvalonia/Views/Node/Connectors/ElementsConnectors.cs
@@ -11,13 +11,9 @@ namespace SimpleStateMachineNodeEditorAvalonia.Views.NodeElements
 {
     public partial class Connectors
     {
-        public ItemsControl ItemsControlConnectors;
-        public ListBox ListBoxConnectors;
         protected override void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-            ListBoxConnectors = this.FindControlWithExeption<ListBox>("ListBoxConnectors");
         }
-
     }
 }

--- a/SimpleStateMachineNodeEditorAvalonia/Views/Node/Header/ElementsHeader.cs
+++ b/SimpleStateMachineNodeEditorAvalonia/Views/Node/Header/ElementsHeader.cs
@@ -10,17 +10,9 @@ namespace SimpleStateMachineNodeEditorAvalonia.Views.NodeElements
 {
     public partial class Header
     {
-        public TextBox TextBoxHeader;
-
-        public ToggleButton ToggleButtonHeader;
-
         protected override void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            TextBoxHeader = this.FindControlWithExeption<TextBox>("TextBoxHeader");
-
-            ToggleButtonHeader = this.FindControlWithExeption<ToggleButton>("ToggleButtonHeader");
         }
     }
 }

--- a/SimpleStateMachineNodeEditorAvalonia/Views/Node/Node/ElementsNode.cs
+++ b/SimpleStateMachineNodeEditorAvalonia/Views/Node/Node/ElementsNode.cs
@@ -11,22 +11,12 @@ namespace SimpleStateMachineNodeEditorAvalonia.Views
 {
     public partial class Node
     {
-        public Border BorderNode;
-        public Header HeaderNode;
-        public LeftConnector InputNode;
-        public RightConnector OutputNode;
-        public Connectors ConnectorsNode;
-
         public TranslateTransform TranslateTransformNode;
+
         protected override void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
 
-            BorderNode      = this.FindControlWithExeption<Border>("BorderNode");
-            HeaderNode      = this.FindControlWithExeption<Header>("HeaderNode");
-            InputNode       = this.FindControlWithExeption<LeftConnector>("InputNode");
-            OutputNode      = this.FindControlWithExeption<RightConnector>("OutputNode");
-            ConnectorsNode = this.FindControlWithExeption<Connectors>("ConnectorsNode");
             TranslateTransformNode = this.RenderTransform as TranslateTransform;
         }
     }

--- a/SimpleStateMachineNodeEditorAvalonia/Views/NodesCanvas/Connects/ElementsConnects.cs
+++ b/SimpleStateMachineNodeEditorAvalonia/Views/NodesCanvas/Connects/ElementsConnects.cs
@@ -9,13 +9,9 @@ namespace SimpleStateMachineNodeEditorAvalonia.Views.NodesCanvasElements
 {
     public partial class Connects
     {
-        public ItemsControl ItemsControlConnects;
-
         protected override void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            ItemsControlConnects = this.FindControlWithExeption<ItemsControl>("ItemsControlConnects");
         }
     }
 }

--- a/SimpleStateMachineNodeEditorAvalonia/Views/NodesCanvas/Nodes/ElementsNodes.cs
+++ b/SimpleStateMachineNodeEditorAvalonia/Views/NodesCanvas/Nodes/ElementsNodes.cs
@@ -9,13 +9,9 @@ namespace SimpleStateMachineNodeEditorAvalonia.Views.NodesCanvasElements
 {
     public partial class Nodes
     {
-        public ItemsControl ItemsControlNodes;
-
         protected override void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            ItemsControlNodes = this.FindControlWithExeption<ItemsControl>("ItemsControlNodes");
         }
     }
 }

--- a/SimpleStateMachineNodeEditorAvalonia/Views/NodesCanvas/NodesCanvas/ElementsNodesCanvas.cs
+++ b/SimpleStateMachineNodeEditorAvalonia/Views/NodesCanvas/NodesCanvas/ElementsNodesCanvas.cs
@@ -10,21 +10,9 @@ namespace SimpleStateMachineNodeEditorAvalonia.Views
 {
     public partial class NodesCanvas
     {
-        public Grid GridNodesCanvas;
-        public Nodes NodesNodesCanvas;
-        public Connects ConnectsNodesCanvas;
-        public Selector SelectorNodesCanvas;
-        public Cutter CutterNodesCanvas;
-
         protected override void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            GridNodesCanvas = this.FindControlWithExeption<Grid>("GridNodesCanvas");
-            NodesNodesCanvas = this.FindControlWithExeption<Nodes>("NodesNodesCanvas");
-            ConnectsNodesCanvas = this.FindControlWithExeption<Connects>("ConnectsNodesCanvas");
-            SelectorNodesCanvas = this.FindControlWithExeption<Selector>("SelectorNodesCanvas");
-            CutterNodesCanvas = this.FindControlWithExeption<Cutter>("CutterNodesCanvas");
         }
 
     }

--- a/SimpleStateMachineNodeEditorAvalonia/Views/Selector/ElementsSelector.cs
+++ b/SimpleStateMachineNodeEditorAvalonia/Views/Selector/ElementsSelector.cs
@@ -10,13 +10,9 @@ namespace SimpleStateMachineNodeEditorAvalonia.Views
 {
     public partial class Selector
     {
-        public Rectangle RectangleSelector;
-
         protected override void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            RectangleSelector = this.FindControlWithExeption<Rectangle>("RectangleSelector");
         }
     }
 }


### PR DESCRIPTION
This PR incorporates the [Avalonia.NameGenerator](https://github.com/avaloniaui/avalonia.namegenerator) in order to avoid calling `this.FindControl<T>` by hand. Requires .NET 5. This tool generates references to named controls declared in XAML at compile time!

<img src="https://hsto.org/webt/6a/j6/v5/6aj6v5vemc3g6zqcks0wm_irg1s.gif" />
